### PR TITLE
Fix Ignore Mouse Events on Windows

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -188,6 +188,7 @@ class NativeWindowViews : public NativeWindow,
 #if defined(OS_WIN)
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
   void SetForwardMouseMessages(bool forward);
+  static BOOL CALLBACK FindLegacyWinFromChildWindowsProc(HWND hWnd, LPARAM lParam);
   static LRESULT CALLBACK SubclassProc(HWND hwnd,
                                        UINT msg,
                                        WPARAM w_param,

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -334,8 +334,8 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
   // It's possible that the legacy_window_ is not set when spawning child
   // windows (ex: window.open JS api). The WM_PARENTNOTIFY gets sent to the
   // initial opener/parent when the legacy window is created, then the legacy
-  // win gets re-attached to the newly spawened window manual grab the legacy
-  // window if it's not yet being tracked
+  // win gets re-attached to the newly created host native window. Here,
+  // manual grab the legacy window if it's not yet being tracked
   if (!legacy_window_) {
     HWND parent_window = this->GetNativeWindowHandle();
     LPARAM native_view = reinterpret_cast<LPARAM>(this);

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -278,7 +278,7 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
         // message to be sent.
         if (!legacy_window_) {
           legacy_window_ = reinterpret_cast<HWND>(l_param);
-        }
+		}
       }
       return false;
     }
@@ -331,6 +331,12 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
 }
 
 void NativeWindowViews::SetForwardMouseMessages(bool forward) {
+	if (!legacy_window_) {
+		HWND parent_window = this->GetNativeWindowHandle();
+		LPARAM native_view = reinterpret_cast<LPARAM>(this);
+		EnumChildWindows(parent_window, FindLegacyWinFromChildWindowsProc, native_view);
+	}
+
   if (forward && !forwarding_mouse_messages_) {
     forwarding_mouse_messages_ = true;
     forwarding_windows_.insert(this);
@@ -354,6 +360,23 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
       mouse_hook_ = NULL;
     }
   }
+}
+
+BOOL CALLBACK NativeWindowViews::FindLegacyWinFromChildWindowsProc(HWND hWnd, LPARAM lParam)
+{
+	if (hWnd) {
+		NativeWindowViews* native_view = reinterpret_cast<NativeWindowViews*>(lParam);
+		wchar_t windowCaption[256];
+		GetWindowTextW(hWnd, &windowCaption[0], 256);
+		if (!wcscmp(windowCaption, L"Chrome Legacy Window")) {
+			native_view->legacy_window_ = hWnd;
+      // stop enumerating windows
+			return false;
+		}
+	}
+
+  // check next window
+	return true;
 }
 
 LRESULT CALLBACK NativeWindowViews::SubclassProc(HWND hwnd,


### PR DESCRIPTION
[cl] Allows using `setIgnoreMouseEvents` on windows without calling `.loadURL` on the browser. Calling `loadURL` is destructive - it clobbers the `window.opener` and breaks synchronous cross-scripting between parent-child windows browser windows