### PR TITLE
Streaming perf patches

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -131,3 +131,4 @@ cherry-pick-f6cb89728f04.patch
 backport_1111737.patch
 add_prepare_web_contents_creation_delegate_for_nativewindow_open.patch
 extend_num_supported_gamepads.patch
+enable_h264_qp_threshold_optional_constraints.patch

--- a/patches/chromium/enable_h264_qp_threshold_optional_constraints.patch
+++ b/patches/chromium/enable_h264_qp_threshold_optional_constraints.patch
@@ -1,0 +1,122 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ciarlillo <alex.ciarlillo@gmail.com>
+Date: Mon, 16 Aug 2021 21:34:49 -0400
+Subject: enable h264 qp threshold optional constraints
+
+allows setting transport-level proprietary constraints ggH264qpHigh
+and ggH264qpLow. These can be used in conjunction with the webrtc
+patch to override default QP values for the H264 encoder.
+
+diff --git a/third_party/blink/public/platform/web_media_constraints.h b/third_party/blink/public/platform/web_media_constraints.h
+index a6877713ab7d80e4c855270c8b401c68e65edb53..bed9a4557dc784ddf00c798dcb4665a7a5ac9d6e 100644
+--- a/third_party/blink/public/platform/web_media_constraints.h
++++ b/third_party/blink/public/platform/web_media_constraints.h
+@@ -279,6 +279,8 @@ struct WebMediaTrackConstraintSet {
+   LongConstraint goog_high_start_bitrate;
+   BooleanConstraint goog_payload_padding;
+   LongConstraint goog_latency_ms;
++  LongConstraint gg_h264_qp_high;
++  LongConstraint gg_h264_qp_low;
+ 
+   BLINK_PLATFORM_EXPORT bool IsEmpty() const;
+   BLINK_PLATFORM_EXPORT bool HasMandatory() const;
+diff --git a/third_party/blink/renderer/modules/mediastream/media_constraints_impl.cc b/third_party/blink/renderer/modules/mediastream/media_constraints_impl.cc
+index 048e9c7014ef109fcd3a9757967aeb82e85b4199..ee3e684090ffab45a7778ed899fa1c8f02f20893 100644
+--- a/third_party/blink/renderer/modules/mediastream/media_constraints_impl.cc
++++ b/third_party/blink/renderer/modules/mediastream/media_constraints_impl.cc
+@@ -128,6 +128,8 @@ const char kCpuOveruseEncodeUsage[] = "googCpuOveruseEncodeUsage";
+ const char kHighStartBitrate[] = "googHighStartBitrate";
+ const char kPayloadPadding[] = "googPayloadPadding";
+ const char kAudioLatency[] = "latencyMs";
++const char kH264qpHigh[] = "ggH264qpHigh";
++const char kH264qpLow[] = "ggH264qpLow";
+ 
+ // Names that have been used in the past, but should now be ignored.
+ // Kept around for backwards compatibility.
+@@ -272,6 +274,8 @@ static void ParseOldStyleNames(
+     bool report_unknown_names,
+     WebMediaTrackConstraintSet& result,
+     MediaErrorState& error_state) {
++  
++
+   for (const NameValueStringConstraint& constraint : old_names) {
+     if (constraint.name_.Equals(kMinAspectRatio)) {
+       result.aspect_ratio.SetMin(atof(constraint.value_.Utf8().c_str()));
+@@ -409,6 +413,10 @@ static void ParseOldStyleNames(
+       result.goog_payload_padding.SetExact(ToBoolean(constraint.value_));
+     } else if (constraint.name_.Equals(kAudioLatency)) {
+       result.goog_latency_ms.SetExact(atoi(constraint.value_.Utf8().c_str()));
++    } else if (constraint.name_.Equals(kH264qpHigh)) {
++      result.gg_h264_qp_high.SetExact(atoi(constraint.value_.Utf8().c_str()));
++    } else if (constraint.name_.Equals(kH264qpLow)) {
++      result.gg_h264_qp_low.SetExact(atoi(constraint.value_.Utf8().c_str()));
+     } else if (constraint.name_.Equals(kGoogLeakyBucket) ||
+                constraint.name_.Equals(kGoogBeamforming) ||
+                constraint.name_.Equals(kGoogArrayGeometry) ||
+@@ -460,6 +468,7 @@ static WebMediaConstraints CreateFromNamedConstraints(
+     Vector<NameValueStringConstraint>& mandatory,
+     const Vector<NameValueStringConstraint>& optional,
+     MediaErrorState& error_state) {
++
+   WebMediaTrackConstraintSet basic;
+   WebMediaTrackConstraintSet advanced;
+   WebMediaConstraints constraints;
+@@ -487,6 +496,7 @@ WebMediaConstraints Create(ExecutionContext* context,
+                            MediaErrorState& error_state) {
+   Vector<NameValueStringConstraint> optional;
+   Vector<NameValueStringConstraint> mandatory;
++
+   if (!Parse(constraints_dictionary, optional, mandatory)) {
+     error_state.ThrowTypeError("Malformed constraints object.");
+     return WebMediaConstraints();
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
+index 5b237e73a43f741aa0beb1ebffac31a1af711413..ee0cc62d16b354733e014b30cd823413709f16da 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
+@@ -214,6 +214,20 @@ void CopyConstraintsIntoRtcConfiguration(
+           &rate)) {
+     configuration->screencast_min_bitrate = rate;
+   }
++  int qpHigh;
++  if (GetConstraintValueAsInteger(
++          constraints,
++          &blink::WebMediaTrackConstraintSet::gg_h264_qp_high,
++          &qpHigh)) {
++    configuration->h264_qp_high = qpHigh;
++  }
++  int qpLow;
++  if (GetConstraintValueAsInteger(
++          constraints,
++          &blink::WebMediaTrackConstraintSet::gg_h264_qp_low,
++          &qpLow)) {
++    configuration->h264_qp_low = qpLow;
++  }
+   configuration->combined_audio_video_bwe = ConstraintToOptional(
+       constraints,
+       &blink::WebMediaTrackConstraintSet::goog_combined_audio_video_bwe);
+diff --git a/third_party/blink/renderer/platform/exported/web_media_constraints.cc b/third_party/blink/renderer/platform/exported/web_media_constraints.cc
+index dcad673ac6788b4fe97a99881a465cbb77515c94..5a4566bf4eb1c927d5a7d5351c7e44a6cc3f56f9 100644
+--- a/third_party/blink/renderer/platform/exported/web_media_constraints.cc
++++ b/third_party/blink/renderer/platform/exported/web_media_constraints.cc
+@@ -387,7 +387,9 @@ WebMediaTrackConstraintSet::WebMediaTrackConstraintSet()
+       goog_cpu_overuse_encode_usage("googCpuOveruseEncodeUsage"),
+       goog_high_start_bitrate("googHighStartBitrate"),
+       goog_payload_padding("googPayloadPadding"),
+-      goog_latency_ms("latencyMs") {}
++      goog_latency_ms("latencyMs"),
++      gg_h264_qp_high("ggH264qpHigh"),
++      gg_h264_qp_low("ggH264qpLow") {}
+ 
+ std::vector<const BaseConstraint*> WebMediaTrackConstraintSet::AllConstraints()
+     const {
+@@ -441,7 +443,9 @@ std::vector<const BaseConstraint*> WebMediaTrackConstraintSet::AllConstraints()
+                                   &goog_cpu_overuse_encode_usage,
+                                   &goog_high_start_bitrate,
+                                   &goog_payload_padding,
+-                                  &goog_latency_ms};
++                                  &goog_latency_ms,
++                                  &gg_h264_qp_high,
++                                  &gg_h264_qp_low};
+   const int element_count = sizeof(temp) / sizeof(temp[0]);
+   return std::vector<const BaseConstraint*>(&temp[0], &temp[element_count]);
+ }

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -2,3 +2,4 @@ backport_1076703.patch
 backport_978779.patch
 check_for_null_before_accessing_sctptransport_map.patch
 enable_support_for_optional_h264_qp_thresholds.patch
+modify_min_and_target_bitrate_calculations.patch

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,3 +1,4 @@
 backport_1076703.patch
 backport_978779.patch
 check_for_null_before_accessing_sctptransport_map.patch
+enable_support_for_optional_h264_qp_thresholds.patch

--- a/patches/webrtc/enable_support_for_optional_h264_qp_thresholds.patch
+++ b/patches/webrtc/enable_support_for_optional_h264_qp_thresholds.patch
@@ -1,0 +1,211 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ciarlillo <alex.ciarlillo@gmail.com>
+Date: Mon, 16 Aug 2021 21:52:57 -0400
+Subject: enable support for optional h264 qp thresholds
+
+partners with Chromium patch for parsing and passing a new
+transport level constraing (ggH264qpHigh & ggH264qpLow) for
+modifying H264 QP values
+
+diff --git a/api/peer_connection_interface.h b/api/peer_connection_interface.h
+index 2ae290c8d6b730c67f59513e3c2a41f325502186..84a2aa98690aba1cfa8191a73b13a4bb923ebdeb 100644
+--- a/api/peer_connection_interface.h
++++ b/api/peer_connection_interface.h
+@@ -412,6 +412,11 @@ class RTC_EXPORT PeerConnectionInterface : public rtc::RefCountInterface {
+     // when switching from a static scene to one with motion.
+     absl::optional<int> screencast_min_bitrate;
+ 
++    // Transport level settings to override the default H264 QP thresholds
++    absl::optional<int> h264_qp_high;
++    absl::optional<int> h264_qp_low;
++
++
+     // Use new combined audio/video bandwidth estimation?
+     absl::optional<bool> combined_audio_video_bwe;
+ 
+diff --git a/api/video_codecs/video_codec.h b/api/video_codecs/video_codec.h
+index a248d19382f1b9723e3e54fd875da84cae5e81d2..0f86ad2ef5a5b6e8ac31e36012b05d8465c2e93b 100644
+--- a/api/video_codecs/video_codec.h
++++ b/api/video_codecs/video_codec.h
+@@ -81,6 +81,8 @@ struct VideoCodecH264 {
+   bool frameDroppingOn;
+   int keyFrameInterval;
+   uint8_t numberOfTemporalLayers;
++  int qpHigh;
++  int qpLow;
+ };
+ 
+ // Translates from name of codec to codec type and vice versa.
+diff --git a/api/video_codecs/video_encoder.cc b/api/video_codecs/video_encoder.cc
+index 417772f1a4cc28f1e0ff79b7ee5a6793b6c8c165..d133d223ed8bee079cdcc943cb99674d2e6dce2f 100644
+--- a/api/video_codecs/video_encoder.cc
++++ b/api/video_codecs/video_encoder.cc
+@@ -56,6 +56,10 @@ VideoCodecH264 VideoEncoder::GetDefaultH264Settings() {
+   h264_settings.keyFrameInterval = 3000;
+   h264_settings.numberOfTemporalLayers = 1;
+ 
++  // these values are taken from h264_encoder_impl.cc
++  h264_settings.qpHigh = 37;
++  h264_settings.qpLow = 24;
++
+   return h264_settings;
+ }
+ 
+diff --git a/media/base/media_channel.h b/media/base/media_channel.h
+index 90c33bd7a6301a0c94f68e113228a786d16dd4d1..32de15d219da1884d6e547a173b8416149a9a864 100644
+--- a/media/base/media_channel.h
++++ b/media/base/media_channel.h
+@@ -110,12 +110,14 @@ struct VideoOptions {
+     SetFrom(&video_noise_reduction, change.video_noise_reduction);
+     SetFrom(&screencast_min_bitrate_kbps, change.screencast_min_bitrate_kbps);
+     SetFrom(&is_screencast, change.is_screencast);
++    SetFrom(&h264_qp_high, change.h264_qp_high);
++    SetFrom(&h264_qp_low, change.h264_qp_low);
+   }
+ 
+   bool operator==(const VideoOptions& o) const {
+     return video_noise_reduction == o.video_noise_reduction &&
+            screencast_min_bitrate_kbps == o.screencast_min_bitrate_kbps &&
+-           is_screencast == o.is_screencast;
++           is_screencast == o.is_screencast && h264_qp_high == o.h264_qp_high && h264_qp_low == o.h264_qp_low;
+   }
+   bool operator!=(const VideoOptions& o) const { return !(*this == o); }
+ 
+@@ -126,6 +128,8 @@ struct VideoOptions {
+     ost << ToStringIfSet("screencast min bitrate kbps",
+                          screencast_min_bitrate_kbps);
+     ost << ToStringIfSet("is_screencast ", is_screencast);
++    ost << ToStringIfSet("h264_qp_high ", h264_qp_high);
++    ost << ToStringIfSet("h264_qp_low ", h264_qp_low);
+     ost << "}";
+     return ost.Release();
+   }
+@@ -144,6 +148,9 @@ struct VideoOptions {
+   // youtube video have different needs.
+   absl::optional<bool> is_screencast;
+ 
++  absl::optional<int> h264_qp_high;
++  absl::optional<int> h264_qp_low;
++
+  private:
+   template <typename T>
+   static void SetFrom(absl::optional<T>* s, const absl::optional<T>& o) {
+diff --git a/media/engine/webrtc_video_engine.cc b/media/engine/webrtc_video_engine.cc
+index a5afcb3fe6336c05cfe6ce5a9f79659c7a8b0b6b..35b77a99688e67f5d8871eaee61ef8a0b370234e 100644
+--- a/media/engine/webrtc_video_engine.cc
++++ b/media/engine/webrtc_video_engine.cc
+@@ -342,6 +342,15 @@ WebRtcVideoChannel::WebRtcVideoSendStream::ConfigureVideoEncoderSettings(
+     webrtc::VideoCodecH264 h264_settings =
+         webrtc::VideoEncoder::GetDefaultH264Settings();
+     h264_settings.frameDroppingOn = frame_dropping;
++
++    if (parameters_.options.h264_qp_high) {
++      h264_settings.qpHigh = parameters_.options.h264_qp_high.value();
++    }
++
++    if (parameters_.options.h264_qp_low) {
++      h264_settings.qpLow = parameters_.options.h264_qp_low.value();
++    }
++
+     return new rtc::RefCountedObject<
+         webrtc::VideoEncoderConfig::H264EncoderSpecificSettings>(h264_settings);
+   }
+diff --git a/modules/video_coding/utility/quality_scaler.cc b/modules/video_coding/utility/quality_scaler.cc
+index a866aeb7644ff991b70f6d97689d5be7c648dd7c..d34489024a5ae63609295d1d3e85d0fea963f4e8 100644
+--- a/modules/video_coding/utility/quality_scaler.cc
++++ b/modules/video_coding/utility/quality_scaler.cc
+@@ -234,6 +234,7 @@ void QualityScaler::CheckQp() {
+ 
+ void QualityScaler::ReportQpLow() {
+   RTC_DCHECK_RUN_ON(&task_checker_);
++  RTC_LOG(LS_INFO) << "ReportQpLow";
+   ClearSamples();
+   observer_->AdaptUp(AdaptationObserverInterface::AdaptReason::kQuality);
+   adapt_called_ = true;
+@@ -241,7 +242,7 @@ void QualityScaler::ReportQpLow() {
+ 
+ void QualityScaler::ReportQpHigh() {
+   RTC_DCHECK_RUN_ON(&task_checker_);
+-
++  RTC_LOG(LS_INFO) << "ReportQpHigh";
+   if (observer_->AdaptDown(
+           AdaptationObserverInterface::AdaptReason::kQuality)) {
+     ClearSamples();
+diff --git a/pc/peer_connection.cc b/pc/peer_connection.cc
+index 0d43da4a513652cef61cc6661eee73a229384907..fbf2978f49013d763ad6c4885cee0f93b9b97221 100644
+--- a/pc/peer_connection.cc
++++ b/pc/peer_connection.cc
+@@ -867,6 +867,8 @@ bool PeerConnectionInterface::RTCConfiguration::operator==(
+     bool disable_link_local_networks;
+     bool enable_rtp_data_channel;
+     absl::optional<int> screencast_min_bitrate;
++    absl::optional<int> h264_qp_high;
++    absl::optional<int> h264_qp_low;
+     absl::optional<bool> combined_audio_video_bwe;
+     absl::optional<bool> enable_dtls_srtp;
+     TcpCandidatePolicy tcp_candidate_policy;
+@@ -938,6 +940,8 @@ bool PeerConnectionInterface::RTCConfiguration::operator==(
+          disable_link_local_networks == o.disable_link_local_networks &&
+          enable_rtp_data_channel == o.enable_rtp_data_channel &&
+          screencast_min_bitrate == o.screencast_min_bitrate &&
++         h264_qp_high == o.h264_qp_high &&
++         h264_qp_low == o.h264_qp_low &&
+          combined_audio_video_bwe == o.combined_audio_video_bwe &&
+          enable_dtls_srtp == o.enable_dtls_srtp &&
+          ice_candidate_pool_size == o.ice_candidate_pool_size &&
+@@ -1359,6 +1363,10 @@ bool PeerConnection::Initialize(
+ 
+   video_options_.screencast_min_bitrate_kbps =
+       configuration.screencast_min_bitrate;
++  video_options_.h264_qp_high =
++      configuration.h264_qp_high;
++  video_options_.h264_qp_low =
++      configuration.h264_qp_low;
+   audio_options_.combined_audio_video_bwe =
+       configuration.combined_audio_video_bwe;
+ 
+@@ -3900,6 +3908,7 @@ PeerConnectionInterface::RTCConfiguration PeerConnection::GetConfiguration() {
+ 
+ RTCError PeerConnection::SetConfiguration(
+     const RTCConfiguration& configuration) {
++
+   RTC_DCHECK_RUN_ON(signaling_thread());
+   TRACE_EVENT0("webrtc", "PeerConnection::SetConfiguration");
+   if (IsClosed()) {
+diff --git a/video/video_stream_encoder.cc b/video/video_stream_encoder.cc
+index 8af9a7d8c0faed4cda4a4362645c89bf581623dc..bbe673cbebc0c4b8ff027687384679d9d4d3e0af 100644
+--- a/video/video_stream_encoder.cc
++++ b/video/video_stream_encoder.cc
+@@ -636,8 +636,10 @@ void VideoStreamEncoder::SetSource(
+     }
+     degradation_preference_ = degradation_preference;
+ 
+-    if (encoder_)
++    if (encoder_) {
++      RTC_LOG(LS_INFO) << " !!!!! VIDEO STREAM ENCODER SET SOURCE";
+       ConfigureQualityScaler(encoder_->GetEncoderInfo());
++    }
+ 
+     if (!IsFramerateScalingEnabled(degradation_preference) &&
+         max_framerate_ != -1) {
+@@ -1029,6 +1031,12 @@ void VideoStreamEncoder::ReconfigureEncoder() {
+       max_framerate_, source_proxy_->GetActiveSinkWants().max_framerate_fps);
+   overuse_detector_->OnTargetFramerateUpdated(target_framerate);
+ 
++  // use encoder specific settings to modify qp threshold limits for h264
++  if (codec.codecType == kVideoCodecH264) {
++    RTC_LOG(LS_INFO) << "Optional settings to override H264 QP thresholds: {" << codec.H264()->qpLow << ", " << codec.H264()->qpHigh << "}";
++    info.scaling_settings = VideoEncoder::ScalingSettings(codec.H264()->qpLow, codec.H264()->qpHigh);
++  }
++  
+   ConfigureQualityScaler(info);
+ }
+ 
+@@ -1050,6 +1058,7 @@ void VideoStreamEncoder::ConfigureQualityScaler(
+         experimental_thresholds = QualityScalingExperiment::GetQpThresholds(
+             encoder_config_.codec_type);
+       }
++
+       // Since the interface is non-public, std::make_unique can't do this
+       // upcast.
+       AdaptationObserverInterface* observer = this;

--- a/patches/webrtc/modify_min_and_target_bitrate_calculations.patch
+++ b/patches/webrtc/modify_min_and_target_bitrate_calculations.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ciarlillo <alex.ciarlillo@gmail.com>
+Date: Mon, 16 Aug 2021 23:39:53 -0400
+Subject: Modify min and target bitrate calculations
+
+
+diff --git a/media/engine/webrtc_video_engine.cc b/media/engine/webrtc_video_engine.cc
+index 35b77a99688e67f5d8871eaee61ef8a0b370234e..7d61c3cdce91d2269406ea962d9a3f4948ef959c 100644
+--- a/media/engine/webrtc_video_engine.cc
++++ b/media/engine/webrtc_video_engine.cc
+@@ -3191,10 +3191,12 @@ std::vector<webrtc::VideoStream> EncoderStreamFactory::CreateEncoderStreams(
+             std::max(layers[i].max_bitrate_bps, layers[i].min_bitrate_bps);
+       } else if (encoder_config.simulcast_layers[i].max_bitrate_bps > 0) {
+         // Only max bitrate is configured, make sure min/target are below max.
++
++        // Guilded Patch Change: default min bps to 1/2 max, and target bps to 2/3
+         layers[i].min_bitrate_bps =
+-            std::min(layers[i].min_bitrate_bps, layers[i].max_bitrate_bps);
++            std::min(layers[i].min_bitrate_bps, static_cast<int>(layers[i].max_bitrate_bps / 2));
+         layers[i].target_bitrate_bps =
+-            std::min(layers[i].target_bitrate_bps, layers[i].max_bitrate_bps);
++            std::min(layers[i].target_bitrate_bps, static_cast<int>(layers[i].max_bitrate_bps * 2 / 3));
+       }
+       if (i == layers.size() - 1) {
+         is_highest_layer_max_bitrate_configured =

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -32,7 +32,8 @@ void InitializeFeatureList() {
   // https://chromium-review.googlesource.com/c/chromium/src/+/1869562
   // Any website which uses older WebComponents will fail in without this
   // enabled, since Electron does not support origin trials.
-  enable_features += std::string(",") + "WebComponentsV0Enabled";
+  enable_features += std::string(",") + "WebComponentsV0Enabled" +
+                     std::string(",") + "AudioWorkletRealtimeThread";
 
 #if !BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
   disable_features += std::string(",") + media::kPictureInPicture.name;


### PR DESCRIPTION
These PR includes 2 patches which span the chromium/blink side and webrtc side.

**Patch 1 (allow passing custom H264 QP Thresholds)**
This patch allows adding new proprietary constraints to a peer connection to override the hard-coded H264 QP threshold parameters. (See the main guilded repo PR for how this is used). We could have more easily just patched the values directly, but this was a good exercise in threading through new optional parameter code so we can a) disable it w/o recompiling electron and b) experiment with these values. This creates a pattern we can follow in the future if we would like to try additional tweaks in this pipeline.

In short, these values are used to trigger resolution increases/decreases when the encoded video is attempting to maintain frame rate (instead of resolution). Increasing these values allows for a more compressed image to be seen during periods of fast scene changes, without actually decreasing the resolution. Once the QP value exceeds the upper threshold, the encoder drops the resolution by 1/2 and it does not reset it until the QP value drops below the lower bound for 2 seconds. Increasing this range decreases the frequency (or chance at all) that resolution will be changed to satisfy framerate.

**Patch 2 (modify min and target bitrate calculations)**
This one is much simpler. Since our current Chrome RTC handler only respects passing `maxBitrate` (and not `minBitrate` or `targetBitrate`) we use the maximum value to calculate more reasonable values for these. In this case we set the minBitrate to 1/2 the maxBitrate. And the target bitrate is 2/3 the maximum. The maximum allows the encoder to hit higher bitrates during periods of many fast changes to the frames, but under normal conditions it attempts to satisfy the target bitrate. The minimum bitrate prevents it from dropping so low (during periods of inactivity / no frame changes) that there is stuttering / dropped frames as when activity resumes and the bitrate needs to ramp up again.

**Non-blink/webrtc patch - electron only**
Enable the audio worklet realtime thread feature.