### PR TITLE
patch OPUS DTX handling

### DIFF
--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,3 +1,4 @@
 add_thread_local_to_x_error_trap_cc.patch
 hdr_screen_capture_fix.patch
 limit_hw_encode_to_highest_quality_simulcast_layer.patch
+patch_opus_dtx_handling.patch

--- a/patches/webrtc/patch_opus_dtx_handling.patch
+++ b/patches/webrtc/patch_opus_dtx_handling.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Ciarlillo <alex.ciarlillo@gmail.com>
+Date: Wed, 16 Nov 2022 17:05:15 -0500
+Subject: patch opus dtx handling
+
+Fix the existing field trial for addressing high energy DTX packets
+on the encode side, as well as add a fix for the decoding side.
+
+diff --git a/modules/audio_coding/codecs/opus/opus_interface.cc b/modules/audio_coding/codecs/opus/opus_interface.cc
+index 033791971f3502ed7e51b2a0a44e1dd6f4bca72c..95e306b19ba4225fab0258ec8b369ffedc7d1151 100644
+--- a/modules/audio_coding/codecs/opus/opus_interface.cc
++++ b/modules/audio_coding/codecs/opus/opus_interface.cc
+@@ -71,8 +71,13 @@ static bool WebRtcOpus_IsHighEnergyRefreshDtxPacket(
+   }
+   int number_frames =
+       frame.size() / DefaultFrameSizePerChannel(inst->sample_rate_hz);
++
++  // Guilded Patch: There is a bug here when checking if a packet has voice activity.
++  // If the packet contains no frames this will return -1 instead of 0, but high energy
++  // DTX packets, according to the encoder, contain no SILK frames even though they do
++  // contain audio data which is picked up on the decoder side.
+   if (number_frames > 0 &&
+-      WebRtcOpus_PacketHasVoiceActivity(encoded.data(), encoded.size()) == 0) {
++      WebRtcOpus_PacketHasVoiceActivity(encoded.data(), encoded.size()) != 1) {
+     const float average_frame_energy =
+         std::accumulate(frame.begin(), frame.end(), 0.0f,
+                         [](float a, int32_t b) { return a + b * b; }) /
+@@ -658,7 +663,11 @@ int WebRtcOpus_Decode(OpusDecInst* inst,
+                       int16_t* audio_type) {
+   int decoded_samples;
+ 
+-  if (encoded_bytes == 0) {
++  // Guilded Patch: "high energy" DTX packets which contain no voice activity
++  // are decoded as normal audio packets and disrupt comfort noise generation because
++  // they reset the internally tracked average sample energy.
++  // We skip regular decoding of packets which do not contain voice activity according to OPUS
++  if (encoded_bytes == 0 || WebRtcOpus_PacketHasVoiceActivity(encoded, encoded_bytes) == 0) {
+     *audio_type = DetermineAudioType(inst, encoded_bytes);
+     decoded_samples = DecodePlc(inst, decoded);
+   } else {


### PR DESCRIPTION
Fix the logic where the current field trial is being checked. The field trial never worked because the "bad" DTX packets were returning `-1` from the `HasVoiceActivity` check instead of `0` because internally they are not seen as having any valid SILK frames.

Apply a similar check on the decode side where we treat non-voice-activity packets as nothing so comfort noise generation algorithm can proceed correctly, otherwise the "bad" DTX packet we receive every 400ms resets the average sample volume, creates a "click" and basically resets the CNG instead of allowing it to taper off.